### PR TITLE
Use bounding_boxes_count

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -67,7 +67,7 @@ int main()
     ei_printf("Begin output\n");
 
 #if EI_CLASSIFIER_OBJECT_DETECTION == 1
-    for (size_t ix = 0; ix < EI_CLASSIFIER_OBJECT_DETECTION_COUNT; ix++) {
+    for (size_t ix = 0; ix < result.bounding_boxes_count; ix++) {
         auto bb = result.bounding_boxes[ix]; 
         if (bb.value == 0) {
             continue;


### PR DESCRIPTION
Use `bounding_boxes_count` instead of the fixed amount of the detected objects.